### PR TITLE
Add German translation

### DIFF
--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -19,5 +19,6 @@ class NFConstants {
   static const List<Locale> supportedLocales = [
     Locale('en', 'US'),
     Locale('ru', 'RU'),
+    Locale('de', 'DE'),
   ];
 }

--- a/lib/src/localization/arb/intl_de.arb
+++ b/lib/src/localization/arb/intl_de.arb
@@ -1,0 +1,27 @@
+{
+  "warning": "Warnung",
+  "@warning": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "close": "Schließen",
+  "@close": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "accept": "Akzeptieren",
+  "@accept": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "cancel": "Abbrechen",
+  "@cancel": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "copied": "Kopiert",
+  "@copied": {
+    "type": "text",
+    "placeholders": {}
+  }
+}

--- a/lib/src/localization/gen/messages_all.dart
+++ b/lib/src/localization/gen/messages_all.dart
@@ -17,11 +17,13 @@ import 'package:intl/src/intl_helpers.dart';
 
 import 'messages_en.dart' as messages_en;
 import 'messages_ru.dart' as messages_ru;
+import 'messages_de.dart' as messages_de;
 
 typedef Future<dynamic> LibraryLoader();
 Map<String, LibraryLoader> _deferredLibraries = {
   'en': () => new Future.value(null),
   'ru': () => new Future.value(null),
+  'de': () => new Future.value(null),
 };
 
 MessageLookupByLibrary? _findExact(String localeName) {
@@ -30,6 +32,8 @@ MessageLookupByLibrary? _findExact(String localeName) {
       return messages_en.messages;
     case 'ru':
       return messages_ru.messages;
+    case 'de':
+      return messages_de.messages;
     default:
       return null;
   }

--- a/lib/src/localization/gen/messages_de.dart
+++ b/lib/src/localization/gen/messages_de.dart
@@ -1,0 +1,30 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a de locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'de';
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => <String, Function> {
+    "accept" : MessageLookupByLibrary.simpleMessage("Akzeptieren"),
+    "cancel" : MessageLookupByLibrary.simpleMessage("Abbrechen"),
+    "close" : MessageLookupByLibrary.simpleMessage("Schließen"),
+    "copied" : MessageLookupByLibrary.simpleMessage("Kopiert"),
+    "warning" : MessageLookupByLibrary.simpleMessage("Warnung")
+  };
+}


### PR DESCRIPTION
Hi, I'm enjoining your [Sweyer music app](https://github.com/nt4f04uNd/sweyer) very much, thank you for creating it and making it open source.

This pull request adds German translations to this module.

I started to translate Sweyer and the app crashed, because the `NFLocalizations.delegate` did not support the German locale.

It would be nice to mention that this module needs to be translated before the Sweyer app in nt4f04uNd/sweyer#10 . In addition, it might be better to filter the supported languages list in the Sweyer app based on the supported languages list of the NFLocalizations delegate.

Additionally, I was unable to generate the code in the `gen` package. The `tool/gen_localizations.bat` is not working for me, it claims that `lib/src/localization/localization.dart` has errors, which isn't the case. It might be beneficial to switch to the `intl` package generation system, which works perfectly in the Sweyer app.